### PR TITLE
Remove goroutines and add obligatory waiting time

### DIFF
--- a/expo/task/help.go
+++ b/expo/task/help.go
@@ -125,6 +125,8 @@ func HTTPPagureGetSupplicant(base string, prms url.Values, password string, want
 		return "", rqex
 	}
 
+	slog.Log(nil, slog.LevelDebug, "Waiting for a couple of seconds before continuing")
+	time.Sleep(2 * time.Second)
 	return string(body), nil
 }
 
@@ -165,6 +167,8 @@ func HTTPForgejoPostSupplicant(base string, data string, password string, want i
 		return "", rqex
 	}
 
+	slog.Log(nil, slog.LevelDebug, "Waiting for a couple of seconds before continuing")
+	time.Sleep(2 * time.Second)
 	return string(body), nil
 }
 


### PR DESCRIPTION
Remove goroutines and add obligatory waiting time

@davidkirwan and I met yesterday, and we were led to believe that it might be the concurrent nature of the codebase that is causing the staging cluster to fail. While I cannot say for certain that was indeed the case as I have not yet looked into the logs, I am attempting to make a synchronous variant of the codebase with a mandatory wait of at least 2 seconds after every request is performed. This is to ensure that in the absence of proper means to protect the deployment against DDoS, we should not be in a state where the resources are exhausted during the migration process. 